### PR TITLE
Add `Formatter` struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -73,36 +73,8 @@ checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
-
-[[package]]
-name = "anyhow"
-version = "1.0.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-
-[[package]]
-name = "assert_cmd"
-version = "2.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
-dependencies = [
- "anstyle",
- "bstr",
- "doc-comment",
- "libc",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -116,7 +88,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -124,17 +96,6 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
-
-[[package]]
-name = "bstr"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde",
-]
 
 [[package]]
 name = "bumpalo"
@@ -210,18 +171,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,31 +181,6 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "errno"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "float-cmp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "futures"
@@ -351,29 +275,13 @@ dependencies = [
 name = "gdscript-formatter"
 version = "0.3.0"
 dependencies = [
- "anyhow",
- "assert_cmd",
  "clap",
- "predicates",
  "regex",
  "similar",
- "tempfile",
  "test_each_file",
  "topiary-core",
  "tree-sitter",
  "tree-sitter-gdscript",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -453,12 +361,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
-
-[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,23 +388,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -545,36 +432,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "predicates"
-version = "3.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
-dependencies = [
- "anstyle",
- "difflib",
- "float-cmp",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
-dependencies = [
- "predicates-core",
- "termtree",
-]
-
-[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,12 +469,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,19 +502,6 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
-
-[[package]]
-name = "rustix"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "rustversion"
@@ -750,25 +588,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tempfile"
-version = "3.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
-dependencies = [
- "fastrand",
- "getrandom",
- "once_cell",
- "rustix",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "termtree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test_each_file"
@@ -897,28 +716,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
-dependencies = [
- "wit-bindgen-rt",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1007,16 +808,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1025,30 +817,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1058,22 +834,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1082,22 +846,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1106,22 +858,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1130,31 +870,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/gdquest/gdscript-formatter"
 default-run = "gdscript-formatter"
 
 [dependencies]
-anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 topiary-core = "0.6"
 tree-sitter-gdscript  = { git = "https://github.com/PrestonKnopp/tree-sitter-gdscript.git", rev = "e7393a9c4d5eb84bcea5d8a22723d4bf9bdd60e3" }
@@ -16,9 +15,6 @@ regex = "1.11"
 tree-sitter = "0.25.9"
 
 [dev-dependencies]
-assert_cmd = "2.0"
-predicates = "3.0"
-tempfile = "3.0"
 test_each_file = "0.3.5"
 similar = "2.7.0"
 
@@ -36,6 +32,4 @@ path = "src/scripts/benchmark.rs"
 
 [profile.release]
 strip = true
-debug = false
-opt-level = 3
 lto = true

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,19 +1,17 @@
-/**
- * This module formats GDScript code using Topiary with tree-sitter to parse and
- * format GDScript files.
- *
- * After the main formatting pass through Topiary, we apply post-processing steps
- * to clean up and standardize the output. These include:
- *
- * - Adding vertical spacing between methods, classes, etc.
- * - Removing unnecessary blank lines that might have been added during formatting
- * - Removing dangling semicolons that sometimes end up on their own lines
- * - Cleaning up lines that contain only whitespace
- * - Optionally reordering code elements according to the GDScript style guide
- *
- * Some of the post-processing is outside of Topiary's capabilities, while other
- * rules have too much performance overhead when applied through Topiary.
- */
+//! This module formats GDScript code using Topiary with tree-sitter to parse and
+//! format GDScript files.
+//!
+//! After the main formatting pass through Topiary, we apply post-processing steps
+//! to clean up and standardize the output. These include:
+//!
+//! - Adding vertical spacing between methods, classes, etc.
+//! - Removing unnecessary blank lines that might have been added during formatting
+//! - Removing dangling semicolons that sometimes end up on their own lines
+//! - Cleaning up lines that contain only whitespace
+//! - Optionally reordering code elements according to the GDScript style guide
+//!
+//! Some of the post-processing is outside of Topiary's capabilities, while other
+//! rules have too much performance overhead when applied through Topiary.
 use std::io::BufWriter;
 
 use regex::RegexBuilder;
@@ -21,6 +19,8 @@ use topiary_core::{formatter, Language, Operation, TopiaryQuery};
 use tree_sitter::{Query, QueryCursor, StreamingIterator, Tree};
 
 use crate::FormatterConfig;
+
+static QUERY: &str = include_str!("../queries/gdscript.scm");
 
 pub fn format_gdscript(content: &str) -> Result<String, Box<dyn std::error::Error>> {
     format_gdscript_with_config(content, &FormatterConfig::default())
@@ -30,217 +30,240 @@ pub fn format_gdscript_with_config(
     content: &str,
     config: &FormatterConfig,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let query = include_str!("../queries/gdscript.scm");
-
-    let indent_string = if config.use_spaces {
-        " ".repeat(config.indent_size)
-    } else {
-        "\t".to_string()
+    let mut formatter = Formatter {
+        input: content.to_owned(),
+        config: config.clone(),
     };
 
-    let language: Language = Language {
-        name: "gdscript".to_owned(),
-        query: TopiaryQuery::new(&tree_sitter_gdscript::LANGUAGE.into(), query).unwrap(),
-        grammar: tree_sitter_gdscript::LANGUAGE.into(),
-        indent: Some(indent_string),
-    };
-
-    let preprocessed_content = preprocess(content);
-
-    let mut input = preprocessed_content.as_bytes();
-    let mut output = Vec::new();
-    let mut writer = BufWriter::new(&mut output);
-
-    let formatter_result = formatter(
-        &mut input,
-        &mut writer,
-        &language,
-        Operation::Format {
-            skip_idempotence: true,
-            tolerate_parsing_errors: true,
-        },
-    );
-
-    if let Err(formatter_error) = formatter_result {
-        return Err(format!("Topiary formatting failed: {}", formatter_error).into());
-    }
-
-    drop(writer);
-
-    let mut formatted_content = String::from_utf8(output)
-        .map_err(|e| format!("Failed to parse topiary output as UTF-8: {}", e))?;
-
-    formatted_content = postprocess(formatted_content);
-    formatted_content = postprocess_tree_sitter(formatted_content);
-
-    if config.reorder_code {
-        formatted_content = crate::reorder::reorder_gdscript_elements(&formatted_content)
-            .unwrap_or_else(|e| {
-                eprintln!("Warning: Code reordering failed: {}. Returning formatted code without reordering.", e);
-                formatted_content
-            });
-    }
-
-    Ok(formatted_content)
+    formatter.preprocess().format()?.postprocess().reorder();
+    Ok(formatter.finish())
 }
 
-/// This function runs postprocess passes that uses tree-sitter.
-fn postprocess_tree_sitter(mut content: String) -> String {
-    let mut parser = tree_sitter::Parser::new();
-    parser
-        .set_language(&tree_sitter_gdscript::LANGUAGE.into())
-        .unwrap();
-    let mut tree = parser.parse(&content, None).unwrap();
-
-    handle_two_blank_line(&mut tree, &mut content);
-
-    content
+struct Formatter {
+    input: String,
+    config: FormatterConfig,
 }
 
-/// This function makes sure we have the correct vertical spacing between important definitions:
-/// Two blank lines between function definitions, inner classes, etc. Taking any
-/// comments or docstrings into account.
-///
-/// This uses tree-sitter to find the relevant nodes and their positions.
-fn handle_two_blank_line(tree: &mut Tree, content: &mut String) {
-    let root = tree.root_node();
-    let sibling_definition_query = match Query::new(
-        &tree_sitter::Language::new(tree_sitter_gdscript::LANGUAGE),
-        "(([(variable_statement) (function_definition) (class_definition) (signal_statement) (const_statement) (enum_definition) (constructor_definition)]) @first
-. ((comment)* @comment . ([(function_definition) (constructor_definition) (class_definition)]) @second))",
-    ) {
-        Ok(q) => q,
-        Err(err) => {
-            panic!("Failed to create query: {}", err);
+impl Formatter {
+    #[inline(always)]
+    fn format(&mut self) -> Result<&mut Self, Box<dyn std::error::Error>> {
+        let indent_string = if self.config.use_spaces {
+            " ".repeat(self.config.indent_size)
+        } else {
+            "\t".to_string()
+        };
+
+        let language = Language {
+            name: "gdscript".to_owned(),
+            query: TopiaryQuery::new(&tree_sitter_gdscript::LANGUAGE.into(), QUERY).unwrap(),
+            grammar: tree_sitter_gdscript::LANGUAGE.into(),
+            indent: Some(indent_string),
+        };
+
+        let mut input = self.input.as_bytes();
+        let mut output = Vec::new();
+        let mut writer = BufWriter::new(&mut output);
+
+        formatter(
+            &mut input,
+            &mut writer,
+            &language,
+            Operation::Format {
+                skip_idempotence: true,
+                tolerate_parsing_errors: true,
+            },
+        )
+        .map_err(|e| format!("Topiary formatting failed: {e}"))?;
+
+        drop(writer);
+
+        self.input = String::from_utf8(output)
+            .map_err(|e| format!("Failed to parse topiary output as UTF-8: {}", e))?;
+
+        Ok(self)
+    }
+
+    #[inline(always)]
+    fn reorder(&mut self) -> &mut Self {
+        if !self.config.reorder_code {
+            return self;
         }
-    };
+        match crate::reorder::reorder_gdscript_elements(&self.input) {
+            Ok(reordered) => {
+                self.input = reordered;
+            }
+            Err(e) => {
+                eprintln!(
+                    "Warning: Code reordering failed: {e}. Returning formatted code without reordering."
+                );
+            }
+        };
+        self
+    }
 
-    // First we need to find all the places where we should add blank lines.
-    // We can't modify the content string while tree-sitter is borrowing it, so we
-    // collect all the positions first, then make changes afterward.
-    let mut new_lines_at = Vec::new();
-    let mut cursor = QueryCursor::new();
-    let mut matches = cursor.matches(&sibling_definition_query, root, content.as_bytes());
-    while let Some(m) = matches.next() {
-        let first_node = m.captures[0].node;
-        if m.captures.len() == 3 {
-            let comment_node = m.captures[1].node;
-            let second_node = m.captures[2].node;
-            // If the @comment is on the same line as the first node,
-            // we'll add a blank line before the @second node
-            if comment_node.start_position().row == first_node.start_position().row {
-                // Find where to insert the new line (before any indentation)
-                let mut byte_idx = second_node.start_byte();
-                let mut position = second_node.start_position();
-                position.column = 0;
-                while content.as_bytes()[byte_idx] != b'\n' {
-                    byte_idx -= 1;
+    /// This function runs over the content before going through topiary.
+    /// It is used to prepare the content for formatting or save performance by
+    /// pre-applying rules that could be performance-intensive through topiary.
+    #[inline(always)]
+    fn preprocess(&mut self) -> &mut Self {
+        self.remove_newlines_after_extends_statement()
+    }
+
+    /// This function runs over the content after going through topiary. We use it
+    /// to clean up/balance out the output.
+    #[inline(always)]
+    fn postprocess(&mut self) -> &mut Self {
+        self.clean_up_lines_with_only_whitespace()
+            .fix_dangling_semicolons()
+            .postprocess_tree_sitter()
+    }
+
+    #[inline(always)]
+    fn finish(self) -> String {
+        self.input
+    }
+
+    /// This function removes additional new line characters after `extends_statement`.
+    #[inline(always)]
+    fn remove_newlines_after_extends_statement(&mut self) -> &mut Self {
+        // This regex matches substrings which:
+        // - must NOT contain "#" or "\n" characters between new line and "extends" keyword
+        // - must end with at least one new line character
+        // - must contain `extends_name` character sequence that satisfies one of the following conditions:
+        //   - consists out of alphanumeric characters
+        //   - consists out of any characters (except new lines) between double quotes
+        let re = RegexBuilder::new(
+            r#"(?P<extends_line>^[^#\n]*extends )(?P<extends_name>([a-zA-Z0-9]+|".*?"))\n(\n*)"#,
+        )
+        .multi_line(true)
+        .build()
+        .expect("regex should compile");
+        self.input = re
+            .replace(&self.input, "$extends_line$extends_name\n")
+            .to_string();
+        self
+    }
+
+    /// This function cleans up lines that contain only whitespace characters
+    /// (spaces, tabs) and a newline character. It only keeps a single newline
+    /// character.
+    #[inline(always)]
+    fn clean_up_lines_with_only_whitespace(&mut self) -> &mut Self {
+        let re = RegexBuilder::new(r"^\s+\n$")
+            .multi_line(true)
+            .build()
+            .expect("empty line regex should compile");
+        self.input = re.replace_all(&self.input, "\n").to_string();
+        self
+    }
+
+    /// This function fixes semicolons that end up on their own line with indentation
+    /// by moving them to the end of the previous line.
+    #[inline(always)]
+    fn fix_dangling_semicolons(&mut self) -> &mut Self {
+        if !self.input.contains(";") {
+            return self;
+        }
+        let re_trailing = RegexBuilder::new(r"\s+;$")
+            .multi_line(true)
+            .build()
+            .expect("semicolon regex should compile");
+        self.input = re_trailing.replace_all(&self.input, "").to_string();
+        self
+    }
+
+    /// This function runs postprocess passes that uses tree-sitter.
+    #[inline(always)]
+    fn postprocess_tree_sitter(&mut self) -> &mut Self {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_gdscript::LANGUAGE.into())
+            .unwrap();
+        let mut tree = parser.parse(&self.input, None).unwrap();
+
+        Self::handle_two_blank_line(&mut tree, &mut self.input);
+
+        self
+    }
+
+    /// This function makes sure we have the correct vertical spacing between important definitions:
+    /// Two blank lines between function definitions, inner classes, etc. Taking any
+    /// comments or docstrings into account.
+    ///
+    /// This uses tree-sitter to find the relevant nodes and their positions.
+    fn handle_two_blank_line(tree: &mut Tree, content: &mut String) {
+        let root = tree.root_node();
+        let sibling_definition_query = match Query::new(
+            &tree_sitter::Language::new(tree_sitter_gdscript::LANGUAGE),
+            "(([(variable_statement) (function_definition) (class_definition) (signal_statement) (const_statement) (enum_definition) (constructor_definition)]) @first
+    . ((comment)* @comment . ([(function_definition) (constructor_definition) (class_definition)]) @second))",
+        ) {
+            Ok(q) => q,
+            Err(err) => {
+                panic!("Failed to create query: {}", err);
+            }
+        };
+
+        // First we need to find all the places where we should add blank lines.
+        // We can't modify the content string while tree-sitter is borrowing it, so we
+        // collect all the positions first, then make changes afterward.
+        let mut new_lines_at = Vec::new();
+        let mut cursor = QueryCursor::new();
+        let mut matches = cursor.matches(&sibling_definition_query, root, content.as_bytes());
+        while let Some(m) = matches.next() {
+            let first_node = m.captures[0].node;
+            if m.captures.len() == 3 {
+                let comment_node = m.captures[1].node;
+                let second_node = m.captures[2].node;
+                // If the @comment is on the same line as the first node,
+                // we'll add a blank line before the @second node
+                if comment_node.start_position().row == first_node.start_position().row {
+                    // Find where to insert the new line (before any indentation)
+                    let mut byte_idx = second_node.start_byte();
+                    let mut position = second_node.start_position();
+                    position.column = 0;
+                    while content.as_bytes()[byte_idx] != b'\n' {
+                        byte_idx -= 1;
+                    }
+                    new_lines_at.push((byte_idx, position));
+                } else {
+                    // Otherwise, add a blank line after the first node
+                    new_lines_at.push((first_node.end_byte(), first_node.end_position()));
                 }
-                new_lines_at.push((byte_idx, position));
             } else {
-                // Otherwise, add a blank line after the first node
+                // If there's no comment between the nodes, add a blank line after the first node
                 new_lines_at.push((first_node.end_byte(), first_node.end_position()));
             }
-        } else {
-            // If there's no comment between the nodes, add a blank line after the first node
-            new_lines_at.push((first_node.end_byte(), first_node.end_position()));
         }
-    }
 
-    // We sort the positions in reverse order so that when we insert new lines,
-    // we don't mess up the positions of the other insertions we need to make.
-    new_lines_at.sort_by(|a, b| b.cmp(a));
+        // We sort the positions in reverse order so that when we insert new lines,
+        // we don't mess up the positions of the other insertions we need to make.
+        new_lines_at.sort_by(|a, b| b.cmp(a));
 
-    for (byte_idx, position) in new_lines_at {
-        let mut new_end_position = position;
-        let mut new_end_byte_idx = byte_idx;
-        // Only add a second blank line if there isn't already one
-        if content.as_bytes()[byte_idx + 1] != b'\n' {
+        for (byte_idx, position) in new_lines_at {
+            let mut new_end_position = position;
+            let mut new_end_byte_idx = byte_idx;
+            // Only add a second blank line if there isn't already one
+            if content.as_bytes()[byte_idx + 1] != b'\n' {
+                new_end_position.row += 1;
+                new_end_byte_idx += 1;
+                content.insert(byte_idx, '\n');
+            }
+            // Add the first blank line
             new_end_position.row += 1;
             new_end_byte_idx += 1;
             content.insert(byte_idx, '\n');
+
+            // Update the tree sitter parse tree to reflect our changes so that any
+            // future processing will work with the correct positions
+            tree.edit(&tree_sitter::InputEdit {
+                start_byte: byte_idx,
+                old_end_byte: byte_idx,
+                new_end_byte: new_end_byte_idx,
+                start_position: position,
+                old_end_position: position,
+                new_end_position,
+            });
         }
-        // Add the first blank line
-        new_end_position.row += 1;
-        new_end_byte_idx += 1;
-        content.insert(byte_idx, '\n');
-
-        // Update the tree sitter parse tree to reflect our changes so that any
-        // future processing will work with the correct positions
-        tree.edit(&tree_sitter::InputEdit {
-            start_byte: byte_idx,
-            old_end_byte: byte_idx,
-            new_end_byte: new_end_byte_idx,
-            start_position: position,
-            old_end_position: position,
-            new_end_position,
-        });
     }
-}
-
-/// This function runs over the content before going through topiary.
-/// It is used to prepare the content for formatting or save performance by
-/// pre-applying rules that could be performance-intensive through topiary.
-fn preprocess(content: &str) -> String {
-    let mut content = content.to_owned();
-
-    content = remove_newlines_after_extends_statement(content);
-
-    content
-}
-
-/// This function runs over the content after going through topiary. We use it
-/// to clean up/balance out the output.
-fn postprocess(mut content: String) -> String {
-    content = clean_up_lines_with_only_whitespace(content);
-    if content.contains(';') {
-        content = fix_dangling_semicolons(content);
-    }
-
-    content
-}
-
-/// Remove additional new line characters after `extends_statement`
-fn remove_newlines_after_extends_statement(mut content: String) -> String {
-    // This regex matches substrings which:
-    // - must NOT contain "#" or "\n" characters between new line and "extends" keyword
-    // - must end with at least one new line character
-    // - must contain `extends_name` character sequence that satisfies one of the following conditions:
-    //   - consists out of alphanumeric characters
-    //   - consists out of any characters (except new lines) between double quotes
-    let re = RegexBuilder::new(
-        r#"(?P<extends_line>^[^#\n]*extends )(?P<extends_name>([a-zA-Z0-9]+|".*?"))\n(\n*)"#,
-    )
-    .multi_line(true)
-    .build()
-    .expect("regex should compile");
-    content = re
-        .replace(&content, "$extends_line$extends_name\n")
-        .to_string();
-    content
-}
-
-/// This function cleans up lines that contain only whitespace characters
-/// (spaces, tabs) and a newline character. It only keeps a single newline
-/// character.
-fn clean_up_lines_with_only_whitespace(mut content: String) -> String {
-    let re = RegexBuilder::new(r"^\s+\n$")
-        .multi_line(true)
-        .build()
-        .expect("empty line regex should compile");
-    content = re.replace_all(&content, "\n").to_string();
-
-    content
-}
-
-/// This function fixes semicolons that end up on their own line with indentation
-/// by moving them to the end of the previous line.
-fn fix_dangling_semicolons(mut content: String) -> String {
-    let re_trailing = RegexBuilder::new(r"\s+;$")
-        .multi_line(true)
-        .build()
-        .expect("semicolon regex should compile");
-    content = re_trailing.replace_all(&content, "").to_string();
-
-    content
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
 pub mod formatter;
 pub mod reorder;
 
-pub use formatter::{format_gdscript, format_gdscript_with_config};
-
+#[derive(Clone)]
 pub struct FormatterConfig {
     pub indent_size: usize,
     pub use_spaces: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     let input_content = match &args.input {
-        Some(file_path) => fs::read_to_string(&file_path)
+        Some(file_path) => fs::read_to_string(file_path)
             .map_err(|e| format!("Failed to read file {}: {}", file_path.display(), e))?,
         None => {
             let mut buffer = String::new();
@@ -96,19 +96,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("File is formatted");
     } else {
         match (args.input.as_ref(), args.stdout) {
-            // If there's no input file, always output to stdout
-            (None, _) => {
-                print!("{}", formatted_content);
-            }
-            // We're reading from a file and the --stdout flag is on: we output to stdout
-            (Some(_), true) => {
-                print!("{}", formatted_content);
-            }
-            // We're reading from a file without the --stdout flag: we overwrite the input file
+            // If we're reading from a file without the --stdout flag: we overwrite the input file
             (Some(input_file), false) => {
                 fs::write(input_file, formatted_content).map_err(|e| {
                     format!("Failed to write to file {}: {}", input_file.display(), e)
                 })?;
+            }
+            // Otherwise we output to stdout
+            _ => {
+                print!("{}", formatted_content);
             }
         }
     }

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -1,15 +1,12 @@
-/**
- * This module exposes a function that reorders GDScript code according to the
- * official GDScript style guide.
- *
- * It works as a separate processing pass that parses the GDScript code using
- * tree-sitter, detects top-level declarations, and reorders them according to
- * the style guide.
- *
- * We assume that you won't run this on every save, but rather manually using
- * a code editor command or task when you're met with a messy file.
- *
- */
+//! This module exposes a function that reorders GDScript code according to the
+//! official GDScript style guide.
+//!
+//! It works as a separate processing pass that parses the GDScript code using
+//! tree-sitter, detects top-level declarations, and reorders them according to
+//! the style guide.
+//!
+//! We assume that you won't run this on every save, but rather manually using
+//! a code editor command or task when you're met with a messy file.
 use tree_sitter::{Node, Query, QueryCursor, StreamingIterator, Tree};
 
 /// This method parses the GDScript content, extracts top-level elements,

--- a/src/scripts/benchmark.rs
+++ b/src/scripts/benchmark.rs
@@ -1,19 +1,19 @@
-/// This module tests the performance of the GDScript formatter. Use this to quickly test the
-/// performance impact of changes to the formatter locally.
-///
-/// Run cargo run --bin benchmark --release to compile and run the benchmark.
-/// You can use it in a shell script to compare performance between two git revisions.
-///
-/// For example, to compare between this commit and the previous one:
-///
-/// ```sh
-/// cargo run --bin benchmark --release > benchmark_results.txt
-/// echo "On previous commit:\n" >> benchmark_results.txt
-/// git checkout HEAD^
-/// cargo run --bin benchmark --release >> benchmark_results.txt
-/// git checkout -
-/// ```
-use gdscript_formatter::{format_gdscript_with_config, FormatterConfig};
+//! This module tests the performance of the GDScript formatter. Use this to quickly test the
+//! performance impact of changes to the formatter locally.
+//!
+//! Run cargo run --bin benchmark --release to compile and run the benchmark.
+//! You can use it in a shell script to compare performance between two git revisions.
+//!
+//! For example, to compare between this commit and the previous one:
+//!
+//! ```sh
+//! cargo run --bin benchmark --release > benchmark_results.txt
+//! echo "On previous commit:\n" >> benchmark_results.txt
+//! git checkout HEAD^
+//! cargo run --bin benchmark --release >> benchmark_results.txt
+//! git checkout -
+//! ```
+use gdscript_formatter::{formatter::format_gdscript_with_config, FormatterConfig};
 use std::{fs, time::Instant};
 
 const ITERATIONS: u16 = 100;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,4 +1,4 @@
-use gdscript_formatter::format_gdscript;
+use gdscript_formatter::formatter::format_gdscript;
 use similar::{ChangeTag, TextDiff};
 use std::fs;
 use std::path::Path;


### PR DESCRIPTION
I felt like formatter.rs was getting a bit disorganized, so I though it would be a good idea to move the formatter into its own struct. This also allows chaining processing steps together, which I think is more readable than constantly passing strings around like we currently do:

```rs
    fn postprocess(&mut self) -> &mut Self {
        self.clean_up_lines_with_only_whitespace()
            .fix_dangling_semicolons()
            .postprocess_tree_sitter()
    }
```

I also did some other minor changes:

- Removed unused dependencies
- Removed redundant `opt-level = 3` and `debug = false` from Cargo.toml, because they are the default for the release profile
- Applied clippy lints
- Converted multi-line comments at the top of some modules to proper module documentation
- Some other minor stylistic changes I forgot about

I didn't change actual logic, this is just stylistic changes.