### PR TITLE
fix annotations comments (closes #30)

### DIFF
--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -217,7 +217,7 @@
 ; we again are using @append_space capture name, but this time we
 ; need to make sure to not add additional space between identifier and open paren
 (annotation) @append_space
-((annotation (identifier) @append_space) @append_empty_softline (#not-match? @append_space "^(onready|export)$"))
+((annotation (identifier) @append_space) @append_empty_softline . (comment)? @do_nothing (#not-match? @append_space "^(onready|export)$"))
 (annotation (arguments "(" @prepend_antispace))
 (function_definition (annotations (annotation) @append_hardline))
 

--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -177,9 +177,6 @@
   (comment)
   (annotation)] @allow_blank_line_before)
 
-; tree-sitter parses @tool statement as an annotation node
-(source . (annotation) @append_hardline)
-
 (setget) @prepend_indent_start @append_indent_end
 (setget ":" @prepend_antispace)
 (setget ":" @append_hardline . (comment)? @do_nothing)

--- a/tests/expected/comments_inline.gd
+++ b/tests/expected/comments_inline.gd
@@ -1,3 +1,4 @@
+@export_group("my_group") # annotation comment
 var prop = 10: # var comment
 	set(value): # set comment
 		prop = value

--- a/tests/input/comments_inline.gd
+++ b/tests/input/comments_inline.gd
@@ -1,3 +1,4 @@
+@export_group("my_group") # annotation comment
 var prop = 10: # var comment
 	set(value): # set comment
 		prop = value


### PR DESCRIPTION
This PR fixes inline comments after annotations (closes #30).
I also removed a rule for the new line after `@tool` annotation, because that gets handled by the later annotation rule. Let me know if it breaks something.

Ideally tree-sitter-gdscript should parse `@export`, `@onready` and `@abstract` as a child annotation of a variable statement even if they are on different lines, so we could remove that #not-match and simplify the rule.