### PR TITLE
Fix inline comments in arrays, dictionaries and enums

### DIFF
--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -82,7 +82,7 @@
 (enumerator_list
   "{" @append_input_softline @append_indent_start
   "}" @prepend_input_softline @prepend_indent_end)
-(enumerator_list "," @append_spaced_softline)
+(enumerator_list "," @append_spaced_softline . (comment)? @do_nothing)
 (enumerator_list) @prepend_space
 
 ; CONSTRUCTORS

--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -28,13 +28,12 @@
 (array
   "[" @append_empty_softline @append_indent_start
   "]" @prepend_empty_softline @append_empty_softline @prepend_indent_end)
+(array "," @append_spaced_softline . (comment)? @do_nothing)
 
-(array "," @append_spaced_softline)
 (dictionary
   "{" @append_empty_softline @append_indent_start
   "}" @prepend_empty_softline @append_empty_softline @prepend_indent_end)
-
-(dictionary "," @append_spaced_softline)
+(dictionary "," @append_spaced_softline . (comment)? @do_nothing)
 (pair ":" @append_space)
 
 ; FUNCTIONS

--- a/tests/expected/comments_inline.gd
+++ b/tests/expected/comments_inline.gd
@@ -5,6 +5,12 @@ var prop = 10: # var comment
 	get: # get comment
 		return prop
 
+enum Foo {
+	A, # Comment
+	B, # Comment
+	C
+}
+
 
 class InnerClass: # class comment
 	pass

--- a/tests/expected/comments_inline.gd
+++ b/tests/expected/comments_inline.gd
@@ -11,6 +11,25 @@ class InnerClass: # class comment
 
 
 func _init(): # constructor comment
+	var lua_dict = {
+		# Comment
+		a = 0, # Comment
+		# Comment
+		b = 1, # Comment
+		# Comment
+	}
+
+	var arr = [
+		1, # Comment
+		2, # Comment
+		# Comment
+		2,
+		# Comment
+		# Comment 2
+		2,
+		# Comment
+		3, # Comment
+	]
 	pass
 
 

--- a/tests/input/comments_inline.gd
+++ b/tests/input/comments_inline.gd
@@ -9,6 +9,25 @@ class InnerClass: # class comment
 	pass
 
 func _init(): # constructor comment
+	var lua_dict = {
+			# Comment
+			a = 0, # Comment
+			# Comment
+			b = 1, # Comment
+			# Comment
+	}
+
+	var arr = [
+		1, # Comment
+		2, # Comment
+		# Comment
+		2,
+		# Comment
+		# Comment 2
+		2,
+		# Comment
+		3,# Comment
+		]
 	pass
 
 func foo(): # func comment

--- a/tests/input/comments_inline.gd
+++ b/tests/input/comments_inline.gd
@@ -5,6 +5,12 @@ var prop = 10: # var comment
 	get: # get comment
 		return prop
 
+enum Foo {
+	A, # Comment
+	B,# Comment
+	C
+}
+
 class InnerClass: # class comment
 	pass
 


### PR DESCRIPTION
This PR fixes inline comments in arrays, dictionaries and enums (closes #36)