### PR TITLE
Fix two blank lines spacing before annotated functions

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -196,7 +196,7 @@ impl Formatter {
         let sibling_definition_query = match Query::new(
             &tree_sitter::Language::new(tree_sitter_gdscript::LANGUAGE),
             "(([(variable_statement) (function_definition) (class_definition) (signal_statement) (const_statement) (enum_definition) (constructor_definition)]) @first
-    . ((comment)* @comment . ([(function_definition) (constructor_definition) (class_definition)]) @second))",
+    . (([(comment) (annotation)])* @comment . ([(function_definition) (constructor_definition) (class_definition)]) @second))",
         ) {
             Ok(q) => q,
             Err(err) => {

--- a/tests/expected/two_lines_spacing_with_annotations.gd
+++ b/tests/expected/two_lines_spacing_with_annotations.gd
@@ -1,0 +1,6 @@
+var test
+
+
+@rpc
+func test_rpc() -> void:
+	pass

--- a/tests/input/two_lines_spacing_with_annotations.gd
+++ b/tests/input/two_lines_spacing_with_annotations.gd
@@ -1,0 +1,4 @@
+var test
+@rpc
+func test_rpc() -> void:
+	pass


### PR DESCRIPTION
This PR adds two blank lines before annotated functions (closes #38)