### PR TITLE
Ensure space after comma between element types in typed dictionaries

### DIFF
--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -21,6 +21,7 @@
 (typed_parameter ":" @append_space)
 (typed_default_parameter ":" @append_space)
 (variable_statement ":" @append_space)
+(subscript_arguments "," @append_space)
 
 ; ARRAY AND DICTIONARY
 ; If the array is on a single line, only insert spaces between values. If it's

--- a/tests/expected/dictionaries.gd
+++ b/tests/expected/dictionaries.gd
@@ -9,3 +9,5 @@ var my_dictionary = { key = "value" }
 var my_dictionary_2 = {
 	key = "value",
 }
+
+var dict: Dictionary[int, int] = { }

--- a/tests/input/dictionaries.gd
+++ b/tests/input/dictionaries.gd
@@ -8,3 +8,5 @@ var my_dictionary = {key = "value"}
 # But only if it fits on one line
 var my_dictionary_2 = {
 	key = "value"}
+
+var dict: Dictionary[int,int] = {}


### PR DESCRIPTION
Fixes https://github.com/GDQuest/GDScript-formatter/issues/49

(I have no idea what I'm doing, but I though I would give it a shot anyway)

I also probably put the rule in the wrong place, but I didn't think of better place (I'm not sure if this rule only applies to dictionaries).