### PR TITLE
Remove trailing comma in singleline arrays/dictionaries/enums/functions

### DIFF
--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -32,6 +32,9 @@
 (array "," @append_spaced_softline . (comment)? @do_nothing)
 (array ((_expression) @append_delimiter (#delimiter! ",") . ","? @do_nothing . (comment)? . "]") (#multi_line_only!))
 
+(array "," @delete . "]" (#single_line_only!))
+(dictionary "," @delete . "}" (#single_line_only!))
+
 (dictionary
   "{" @append_empty_softline @append_indent_start
   "}" @prepend_empty_softline @prepend_indent_end)
@@ -50,7 +53,9 @@
 (function_definition) @prepend_hardline
 "->" @prepend_space @append_space
 (arguments "," @append_space (#single_line_only!))
+(arguments "," @delete . ")" (#single_line_only!))
 (parameters "," @append_space (#single_line_only!))
+(parameters "," @delete . ")" (#single_line_only!))
 
 ; MULTI-LINE ARGUMENTS (in function calls)
 (arguments "," @append_hardline (#multi_line_only!))
@@ -93,6 +98,7 @@
 (enumerator_list "," @append_spaced_softline . (comment)? @do_nothing)
 (enumerator_list ((enumerator) @append_delimiter (#delimiter! ",") . ","? @do_nothing . (comment)? . "}") (#multi_line_only!))
 (enumerator_list) @prepend_space
+(enumerator_list "," @delete . "}" (#single_line_only!))
 
 ; CONSTRUCTORS
 (constructor_definition (body) @prepend_hardline)

--- a/tests/expected/trailing_comma.gd
+++ b/tests/expected/trailing_comma.gd
@@ -60,3 +60,11 @@ func f():
 		1,
 		2,
 	)
+
+
+func test(a: int, b: int):
+	pass
+
+
+func test():
+	print("test", "test")

--- a/tests/input/trailing_comma.gd
+++ b/tests/input/trailing_comma.gd
@@ -4,7 +4,7 @@ var a = [
 	3
 ]
 
-var aa = [1, 2, 3]
+var aa = [1, 2, 3,]
 
 var b = [
 	1,
@@ -24,7 +24,7 @@ var d = {
 	"c": 3
 }
 
-var dd = {"a": 1, "b": 2, "c": 3}
+var dd = {"a": 1, "b": 2, "c": 3,}
 
 enum Foo {
 	A,
@@ -38,7 +38,7 @@ enum Foo2 {
 	C # comment
 }
 
-enum Foo3 {A, B, C}
+enum Foo3 {A, B, C,}
 
 func foo(
 	a,
@@ -59,3 +59,11 @@ func f():
 		1,
 		2
 	)
+
+
+func test(a: int, b: int,):
+	pass
+
+
+func test():
+	print("test", "test",)


### PR DESCRIPTION
Hopefully it doesn't delete anything that it didn't need to.