### PR TITLE
Fix inline comments in function calls

### DIFF
--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -59,7 +59,7 @@
 (parameters "," @delete . ")" (#single_line_only!))
 
 ; MULTI-LINE ARGUMENTS (in function calls)
-(arguments "," @append_hardline (#multi_line_only!))
+(arguments "," @append_hardline . (comment)? @do_nothing (#multi_line_only!))
 ; uncomment for double indentation in multiline function calls
 ; (arguments (_) @prepend_indent_start @append_indent_end)
 (arguments

--- a/tests/expected/comments_inline.gd
+++ b/tests/expected/comments_inline.gd
@@ -62,4 +62,9 @@ func foo(): # func comment
 	var lam = func(): # lambda comment
 		pass
 
+	bar(
+		a, # function call inline comment
+		b,
+	)
+
 	return # function trailing comment at end

--- a/tests/input/comments_inline.gd
+++ b/tests/input/comments_inline.gd
@@ -59,4 +59,9 @@ func foo(): # func comment
 	var lam = func(): # lambda comment
 		pass
 
+	bar(
+		a, # function call inline comment
+		b,
+	)
+
 	return # function trailing comment at end


### PR DESCRIPTION
This PR fixes inline comments in function calls.
Previously inline comments were placed on a new line after formatting.

``` gdscript
foo(
    a, # inline
    b,
)
```
were formatted as
``` gdscript
foo(
    a,
    # inline
    b,
)
```
now it formats correctly as
``` gdscript
foo(
    a, # inline
    b,
)
```