### PR TITLE
Don't add space after bitwise NOT

### DIFF
--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -124,8 +124,7 @@
 [
   "&" "|" "^" "<<" ">>"]
 @prepend_space @append_space
-; ~ is generally right next to the variable it operates on, so we don't add a space before it
-"~" @append_space
+; ~ is generally right next to the variable it operates on, so we don't add a space after it
 [
     "=" ":=" "+=" "-=" "*=" "/=" "%=" "**=" "&=" "|=" "^=" "<<=" ">>="]
 @prepend_space @append_space

--- a/tests/expected/operators.gd
+++ b/tests/expected/operators.gd
@@ -5,3 +5,4 @@ func foo():
 	a = (1 + 2)
 	a = (1 | 2 | 3)
 	a = false && true
+	a = ~1

--- a/tests/input/operators.gd
+++ b/tests/input/operators.gd
@@ -5,3 +5,4 @@ func foo():
 	a = (   1+2 )
 	a = ( 1    | 2|3    )
 	a = false&&    true
+	a = ~ 1


### PR DESCRIPTION
There was a comment about not adding a space after it, but the next line did it anyways, so I fixed it. I also believe the comment meant to say _after_, not _before_, because it's usually written as `~x`, not `x~`, so I also updated the comment: before -> after.