### PR TITLE
Misc fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gdscript-formatter"
 version = "0.8.1"
-edition = "2021"
+edition = "2024"
 description = "A GDScript code formatter using Topiary and Tree-sitter"
 license = "MIT"
 repository = "https://github.com/gdquest/gdscript-formatter"

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ To add new formatting rules to the GDScript formatter, you can follow these step
 
 Here are the most important directories and files in the project:
 
-- `src/`: Contains the Rust code to compile and run the formatter using the CLI. It's currently a simple wrapper around the Topiary command line program, but later it could use Topiary as a library instead to pack everything into a simple binary.
+- `src/`: Contains the Rust code to compile and run the formatter using the CLI.
 - `tests/`: Contains test files for the formatter. It has input files with unformatted GDScript code and expected output files that the formatter should produce when run on the input files.
 - `queries/`: Contains the Topiary formatting rules for GDScript. The `gdscript.scm` file is where you define how GDScript code should be formatted based on Tree Sitter queries and Topiary features to mark nodes/patterns for formatting.
 - `config/`: Contains configuration files for Topiary - basically a small file that tells Topiary how to run the formatter for GDScript.


### PR DESCRIPTION
A bunch of minor fixes

- Updated readme, removed info that isn't relevant anymore.
- Changed Rust editon to 2024 to be able to use [let chains](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/#let-chains) in `reorder.rs`
- `formatter.rs`:
  - Don't copy file content if `replace_all` didn't replace anything
  - Make `handle_two_blank_line()` a method of `Formatter`.
- `reorder.rs`:
  - Removed hardcoded priorities from `BUILTIN_VIRTUAL_METHODS`.
  - `extract_*_name()` methods: updated to use methods like `strip_prefix()` and `split_once()` instead of manual string manipulation
  - Added periods to some docstrings