### PR TITLE
Add flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1758758545,
+        "narHash": "sha256-NU5WaEdfwF6i8faJ2Yh+jcK9vVFrofLcwlD/mP65JrI=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "95d528a5f54eaba0d12102249ce42f4d01f4e364",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758701979,
+        "narHash": "sha256-c7DUti3XM1aga8oVgaPnrVmEeCFtN9PaBxyNuqx8jPc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e2642aa7d5a15eae586932a56f4294934f959c14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    crane.url = "github:ipetkov/crane";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      crane,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        craneLib = crane.mkLib pkgs;
+        gdscript-formatter = craneLib.buildPackage {
+          src = ./.;
+
+          cargoExtraArgs = "--bin=gdscript-formatter";
+        };
+      in
+      {
+        packages.default = gdscript-formatter;
+
+        devShells.default = craneLib.devShell {
+          inputsFrom = [ gdscript-formatter ];
+        };
+
+        checks = {
+          inherit gdscript-formatter;
+        };
+      }
+    );
+}


### PR DESCRIPTION
- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #74

I'm [still working on packaging](https://github.com/NixOS/nixpkgs/pull/445935) for nixpkgs itself, but here is the flake I mentioned in #74. Until this is merged, just replace `github:GDQuest/GDScript-formatter` with `github:squarepear/GDScript-formatter/add-nix-support` for anyone wanting to try it out!

```bash
# Run command without adding to path
nix run github:GDQuest/GDScript-formatter -- path/to/script.gd

# Enter shell with command added to path
nix shell github:GDQuest/GDScript-formatter
```

For people contributing to this project, there is also a devshell, which enters a shell with rust/cargo installed.
```bash
git clone https://github.com/GDQuest/GDScript-formatter
cd GDScript-formatter
nix develop -c $SHELL
```