### PR TITLE
Fix newlines in multiline ternaries being removed

### DIFF
--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -212,7 +212,9 @@
 
 ; This is for ternary expressions, e.g. `a if b else c`
 (conditional_expression [("if") ("else")] @prepend_space @append_space)
+(parenthesized_expression (conditional_expression ("if") @prepend_input_softline))
 (parenthesized_expression (conditional_expression ("else") @prepend_input_softline))
+(conditional_expression (conditional_expression ("if") @prepend_input_softline))
 (conditional_expression (conditional_expression ("else") @prepend_input_softline))
 
 (parenthesized_expression "(" @append_antispace)

--- a/tests/expected/multiline.gd
+++ b/tests/expected/multiline.gd
@@ -7,6 +7,16 @@ func foo():
 		else "northwest"
 	)
 
+	var quadrant_newlines = (
+		"northeast"
+		if angle_degrees <= 90
+		else "southeast"
+		if angle_degrees <= 180
+		else "southwest"
+		if angle_degrees <= 270
+		else "northwest"
+	)
+
 	var position = Vector2(250, 350)
 	if (
 		position.x > 200 and position.x < 400

--- a/tests/input/multiline.gd
+++ b/tests/input/multiline.gd
@@ -8,6 +8,18 @@ func foo():
 			else "northwest"
 	)
 
+	var quadrant_newlines = (
+		"northeast"
+		if angle_degrees <= 90     
+		else "southeast"
+
+		if angle_degrees <= 180
+		else "southwest"
+
+		if angle_degrees <= 270    
+		else "northwest"
+	)
+
 	var position = Vector2(250, 350)
 	if (
 			position.x > 200 and position.x < 400


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #90

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

This fixes newlines inside of multiline ternary expressions being remove.

**Does this PR introduce a breaking change?**

No

## New feature or change ##


**What is the current behavior?** 

A good example of is when you have long ternary like so:

```gdscript
func _handle_look_input():
	var input_dir := (
		Input.get_vector(&"look_left", &"look_right", &"look_up", &"look_down")
		if _can_move()
		else Vector2.ZERO
	)
```

This will currently ignore the newline before the `if` and be turned into:

```gdscript
func _handle_look_input():
	var input_dir := (
		Input.get_vector(&"look_left", &"look_right", &"look_up", &"look_down") if _can_move()
		else Vector2.ZERO
	)
```

**What is the new behavior?**

Now, the newline inside of the parenthesis will be preserved.

```gdscript
func _handle_look_input():
	var input_dir := (
		Input.get_vector(&"look_left", &"look_right", &"look_up", &"look_down")
		if _can_move()
		else Vector2.ZERO
	)
```

**Other information**
