### PR TITLE
Handle type_subscript arguments

### DIFF
--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -24,6 +24,7 @@
 (typed_default_parameter ":" @append_space)
 (variable_statement ":" @append_space)
 (subscript_arguments "," @append_space)
+(type_subscript_arguments "," @append_space)
 
 ; ARRAY AND DICTIONARY
 ; If the array is on a single line, only insert spaces between values. If it's


### PR DESCRIPTION
Fixes #95 

**NOTE:** This is only needed if https://github.com/PrestonKnopp/tree-sitter-gdscript/pull/63 gets merged, and this should **not** be merged until that change is merged + published and the newer version is used here.

This handles adding the space between the type parameters i.e. `Dictionary[int, int]`