### PR TITLE
Improve performance of class name and extends queries

### DIFF
--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -90,10 +90,7 @@
         extends: (extends_statement) @prepend_hardline @append_delimiter (#delimiter! "\n")) @append_hardline)
 (source
     (extends_statement) @append_hardline @append_delimiter (#delimiter! "\n"))
-(source
-    (class_name_statement) @append_hardline
-    .
-    (extends_statement))
+(source (class_name_statement (name) @append_hardline))
 
 ; CONST DEFINITIONS
 (const_statement ":" @append_space)

--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -87,9 +87,9 @@
 
 (source
     (class_name_statement
-        extends: (extends_statement) @prepend_hardline @append_delimiter (#delimiter! "\n")) @append_hardline)
+        extends: (extends_statement) @append_delimiter @append_hardline (#delimiter! "\n")))
 (source
-    (extends_statement) @append_hardline @append_delimiter (#delimiter! "\n"))
+    (extends_statement) @append_delimiter @append_hardline (#delimiter! "\n"))
 (source (class_name_statement (name) @append_hardline))
 
 ; CONST DEFINITIONS


### PR DESCRIPTION
This PR improves performance a little bit of class name and extends queries (close #94).

On my machine this saves around 2-4ms.

I also changed order of `@append_hardline` and `@append_delimiter` to ensure that only one empty line is inserted after extends statement, without that one test was failing (there is still two tests related to code reordering that fail, they were failing before this PR).