### PR TITLE
Fix #endregion right after #region getting collapsed

### DIFF
--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -172,6 +172,8 @@
  . (comment)? @do_nothing)
 
 (comment) @append_empty_softline @prepend_input_softline
+(region_start) @append_empty_softline @prepend_input_softline  
+(region_end) @append_empty_softline @prepend_input_softline
 
 ; Allow one blank line before following statements
 ([(return_statement)
@@ -191,6 +193,8 @@
   (while_statement)
   (match_statement)
   (comment)
+  (region_start)
+  (region_end)
   (annotation)] @allow_blank_line_before)
 
 (setget) @prepend_indent_start @append_indent_end

--- a/tests/expected/regions.gd
+++ b/tests/expected/regions.gd
@@ -2,3 +2,8 @@
 func test():
 	pass
 #endregion
+
+#region AnotherRegion
+func test2():
+	pass
+#endregion

--- a/tests/input/regions.gd
+++ b/tests/input/regions.gd
@@ -2,3 +2,8 @@
 func test():
 	pass
 #endregion
+
+#region AnotherRegion
+func test2():
+	pass
+#endregion


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What is the current behavior?** 

Input:
```gdscript
#region Description
func test():
	pass
#endregion

#region AnotherRegion
func test2():
	pass
#endregion
```

Output:
```gdscript
#region Description
func test():
	pass
#endregion#region AnotherRegion
func test2():
	pass
#endregion
```

**What is the new behavior?**

Newlines after `#region` / before `#endregion` are preserved

```gdscript
#region Description
func test():
	pass
#endregion

#region AnotherRegion
func test2():
	pass
#endregion
```

**Other information**
Not sure if this is related to this comment? https://github.com/GDQuest/GDScript-formatter/blob/2ffdce97ef6088491b35e18bb1d029f6d79331e5/src/reorder.rs#L291-L297