### PR TITLE
Fix broken multiline statement docstrings

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -365,8 +365,21 @@ impl Formatter {
                         if last_comment_is_doc_comment {
                             let mut comment_node_index = m.captures.len() - 2;
 
+                            let first_comment_node = m.captures[1].node;
+                            let first_comment_is_inline_comment =
+                                first_comment_node.start_position().row
+                                    == first_node.start_position().row;
+                            // ignore n first nodes when searching for the first docstring comment node
+                            // in case if the first comment is an inline comment we ignore
+                            // two nodes: first statement node and inline comment node
+                            // otherwise we ignore only the first statement node
+                            let mut amount_of_nodes_to_ignore = 1;
+                            if first_comment_is_inline_comment {
+                                amount_of_nodes_to_ignore += 1;
+                            }
+
                             // find first documentation comment node
-                            while comment_node_index > 2
+                            while comment_node_index > amount_of_nodes_to_ignore
                                 && m.captures[comment_node_index - 1].node.start_position().row
                                     == m.captures[comment_node_index].node.start_position().row - 1
                             {

--- a/tests/expected/two_lines_spacing_with_comments.gd
+++ b/tests/expected/two_lines_spacing_with_comments.gd
@@ -6,6 +6,12 @@ func test2() -> void:
 	pass
 
 
+# Multiline docstring
+# another line
+func test2() -> void:
+	pass
+
+
 var a # case 2
 
 

--- a/tests/input/two_lines_spacing_with_comments.gd
+++ b/tests/input/two_lines_spacing_with_comments.gd
@@ -4,6 +4,11 @@ var a
 func test2() -> void:
 	pass
 
+# Multiline docstring
+# another line
+func test2() -> void:
+	pass
+
 var a # case 2
 
 func test2() -> void:


### PR DESCRIPTION
This PR fixes a case with multiline docstrings that I missed in #102.
Previously formatter transformed
```gdscript
var a = 10

## This is function docstring
## It has multiple lines.
func a():
	pass
```
into
```gdscript
var a = 10

## This is function docstring


## It has multiple lines.
func a():
	pass
```
With this PR formatter no longer inserts new lines in the middle of a docstring.