### PR TITLE
Fix issue with trailing comment after statements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-gdscript"
 version = "6.0.0"
-source = "git+https://github.com/PrestonKnopp/tree-sitter-gdscript.git?rev=55d1b51f9ab6c60c21098935014b5431f0ec7ef0#55d1b51f9ab6c60c21098935014b5431f0ec7ef0"
+source = "git+https://github.com/PrestonKnopp/tree-sitter-gdscript.git?rev=0b9f60ebaa1c31f5153dd3a3b283ca0725734378#0b9f60ebaa1c31f5153dd3a3b283ca0725734378"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-run = "gdscript-formatter"
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
 topiary-core = { git = "https://github.com/tweag/topiary", rev = "5081ccef9245fe56c2b3e2a7ced52277eda45825" }
-tree-sitter-gdscript  = { git = "https://github.com/PrestonKnopp/tree-sitter-gdscript.git", rev = "55d1b51f9ab6c60c21098935014b5431f0ec7ef0" }
+tree-sitter-gdscript  = { git = "https://github.com/PrestonKnopp/tree-sitter-gdscript.git", rev = "0b9f60ebaa1c31f5153dd3a3b283ca0725734378" }
 regex = "1.11"
 tree-sitter = "0.25.10"
 rayon = "1.11.0"

--- a/tests/expected/comments_basic.gd
+++ b/tests/expected/comments_basic.gd
@@ -11,3 +11,17 @@ var a = 10 # inline comment
 
 var b = 10
 # after statement comment
+
+func do_thing() -> void:
+	if true:
+		# this is a comment inside of the function block
+		pass
+
+		# this is a comment at the end of the function block
+		# it should stay inside of this function block
+
+
+func do_another_thing() -> void:
+	pass
+
+	# likewise, this comment should stay inside of this function block

--- a/tests/input/comments_basic.gd
+++ b/tests/input/comments_basic.gd
@@ -11,3 +11,17 @@ var a = 10 # inline comment
 
 var b = 10
 # after statement comment
+
+func do_thing() -> void:
+	if true:
+		# this is a comment inside of the function block
+		pass
+		
+		# this is a comment at the end of the function block
+		# it should stay inside of this function block
+
+
+func do_another_thing() -> void:
+	pass
+
+	# likewise, this comment should stay inside of this function block


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

This pulls in the most recent commit from [tree-sitter-gdscript](https://github.com/PrestonKnopp/tree-sitter-gdscript) which has some fixes to trailing comments... while testing that out, I found some other issues with them 😅 

**Does this PR introduce a breaking change?**

No

## New feature or change ##


**What is the current behavior?** 

Currently, when you have a comment after a statement followed by another statement:

```gdscript
var b = 10
# after statement comment

func do_thing() -> void:
	if true:
		# this is a comment inside of the function block
		pass
```

The comment after that first statement gets caught up inside of `handle_two_blank_line` and gets moved down:

```gdscript
var b = 10

# after statement comment
func do_thing() -> void:
	if true:
		# this is a comment inside of the function block
		pass
```

We probably want the comment to stay where it is.

**What is the new behavior?**

The comment is not moved 😉 

**Other information**

This also tests the recent tree-sitter changes to keep comments inside of their blocks
