### PR TITLE
Update tree sitter trailing comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-gdscript"
 version = "6.0.0"
-source = "git+https://github.com/PrestonKnopp/tree-sitter-gdscript.git?rev=55d1b51f9ab6c60c21098935014b5431f0ec7ef0#55d1b51f9ab6c60c21098935014b5431f0ec7ef0"
+source = "git+https://github.com/PrestonKnopp/tree-sitter-gdscript.git?rev=0b9f60ebaa1c31f5153dd3a3b283ca0725734378#0b9f60ebaa1c31f5153dd3a3b283ca0725734378"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-run = "gdscript-formatter"
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
 topiary-core = { git = "https://github.com/tweag/topiary", rev = "5081ccef9245fe56c2b3e2a7ced52277eda45825" }
-tree-sitter-gdscript  = { git = "https://github.com/PrestonKnopp/tree-sitter-gdscript.git", rev = "55d1b51f9ab6c60c21098935014b5431f0ec7ef0" }
+tree-sitter-gdscript  = { git = "https://github.com/PrestonKnopp/tree-sitter-gdscript.git", rev = "0b9f60ebaa1c31f5153dd3a3b283ca0725734378" }
 regex = "1.11"
 tree-sitter = "0.25.10"
 rayon = "1.11.0"

--- a/tests/expected/await.gd
+++ b/tests/expected/await.gd
@@ -1,0 +1,3 @@
+var normal = await test()
+
+var negated := not await test()

--- a/tests/expected/comments_basic.gd
+++ b/tests/expected/comments_basic.gd
@@ -11,3 +11,18 @@ var a = 10 # inline comment
 
 var b = 10
 # after statement comment
+
+
+func do_thing() -> void:
+	if true:
+		# this is a comment inside of the function block
+		pass
+
+		# this is a comment at the end of the function block
+		# it should stay inside of this function block
+
+
+func do_another_thing() -> void:
+	pass
+
+	# likewise, this comment should stay inside of this function block

--- a/tests/input/await.gd
+++ b/tests/input/await.gd
@@ -1,0 +1,5 @@
+
+var normal = await
+	test()
+	
+var negated  :=    not await test()

--- a/tests/input/comments_basic.gd
+++ b/tests/input/comments_basic.gd
@@ -11,3 +11,17 @@ var a = 10 # inline comment
 
 var b = 10
 # after statement comment
+
+func do_thing() -> void:
+	if true:
+		# this is a comment inside of the function block
+		pass
+		
+		# this is a comment at the end of the function block
+		# it should stay inside of this function block
+
+
+func do_another_thing() -> void:
+	pass
+
+	# likewise, this comment should stay inside of this function block


### PR DESCRIPTION
Fixes #68
Fixes #100

This updates `tree-sitter-gdscript` to its latest commit to pick up https://github.com/PrestonKnopp/tree-sitter-gdscript/pull/64 and https://github.com/PrestonKnopp/tree-sitter-gdscript/pull/66

Also added tests to handle the two cases mentioned in those issues