### PR TITLE
Print file name if there is only one file formatted

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -229,11 +229,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     } else if !args.stdout {
         terminal_clear_line();
-        eprintln!(
-            "\rFormatted {} file{}",
-            total_files,
-            if total_files == 1 { "" } else { "s" }
-        );
+        if total_files == 1 {
+            eprintln!(
+                "\rFormatted {}",
+                input_gdscript_files[0].display()
+            );
+        } else {
+            eprintln!(
+                "\rFormatted {} files",
+                total_files
+            );
+        }
     }
 
     Ok(())


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

Now, when formatting one file, instead of printing:

```sh
Formatted 1 file
```

It will print:

```sh
Formatted ./demo/src/Player.gd
```

This is mainly because I was using this to format all my scripts in my project:

```sh
find . -name "*.gd" -type f -not -path "./addons/*" -exec gdscript-formatter {} \;
```

Although I also just realized that you can do this to format them all at once which is way faster 😛 
```sh
find . -name "*.gd" -type f -not -path "./addons/*" -exec gdscript-formatter {} +
```