### PR TITLE
Set `max_term_width` to 80

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ struct FormatterOutput {
 #[clap(
     // Use the version number directly from Cargo.toml at compile time
     version = env!("CARGO_PKG_VERSION"),
-    max_term_width = 80
+    max_term_width = 120
 )]
 struct Args {
     /// The GDScript file(s) to format. If no file paths are provided, the


### PR DESCRIPTION
Closes https://github.com/GDQuest/GDScript-formatter/issues/127

This required enabling `wrap_help` feature for `clap`.