### PR TITLE
Do not reorder elements alphabetically

### DIFF
--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -137,27 +137,6 @@ impl GDScriptTokenKind {
         }
     }
 
-    /// Returns the name of the element. This is used to sort elements of the
-    /// same type alphabetically.
-    pub fn get_name(&self) -> &str {
-        match self {
-            GDScriptTokenKind::ClassAnnotation(name) => name,
-            GDScriptTokenKind::ClassName(name) => name,
-            GDScriptTokenKind::Extends(name) => name,
-            GDScriptTokenKind::Docstring(name) => name,
-            GDScriptTokenKind::Signal(name, _) => name,
-            GDScriptTokenKind::Enum(name, _) => name,
-            GDScriptTokenKind::Constant(name, _) => name,
-            GDScriptTokenKind::StaticVariable(name, _) => name,
-            GDScriptTokenKind::ExportVariable(name, _) => name,
-            GDScriptTokenKind::RegularVariable(name, _) => name,
-            GDScriptTokenKind::OnReadyVariable(name, _) => name,
-            GDScriptTokenKind::Method(name, _, _) => name,
-            GDScriptTokenKind::InnerClass(name, _) => name,
-            GDScriptTokenKind::Unknown(name) => name,
-        }
-    }
-
     /// Returns whether this element is private (starts with underscore).
     pub fn is_private(&self) -> bool {
         match self {
@@ -744,7 +723,7 @@ fn sort_gdscript_tokens(
             return privacy_cmp;
         }
 
-        // Finally we sort alphabetically. We also handle the top annotations up here.
+        // Finally, we handle the top annotations
         match (&a.token_kind, &b.token_kind) {
             (
                 GDScriptTokenKind::ClassAnnotation(a_text),
@@ -767,7 +746,7 @@ fn sort_gdscript_tokens(
                 };
                 a_priority.cmp(&b_priority)
             }
-            _ => a.token_kind.get_name().cmp(b.token_kind.get_name()),
+            _ => std::cmp::Ordering::Equal,
         }
     });
 

--- a/tests/expected/comments_basic.gd
+++ b/tests/expected/comments_basic.gd
@@ -30,5 +30,5 @@ func do_another_thing() -> void:
 
 func test_function():
 	var a = "test"
-# This comment should stay inside of the function body
+	# This comment should stay inside of the function body
 	print(a)

--- a/tests/reorder_code/expected/reorder_annotations.gd
+++ b/tests/reorder_code/expected/reorder_annotations.gd
@@ -2,10 +2,10 @@ class_name Test
 extends Node
 
 
-func a():
+@rpc("authority", "call_remote", "reliable")
+func my_rpc():
 	pass
 
 
-@rpc("authority", "call_remote", "reliable")
-func my_rpc():
+func a():
 	pass

--- a/tests/reorder_code/expected/reorder_class_docstring.gd
+++ b/tests/reorder_code/expected/reorder_class_docstring.gd
@@ -4,9 +4,9 @@ extends Node
 ## It has multiple lines.
 
 
-func a():
+func b():
 	pass
 
 
-func b():
+func a():
 	pass

--- a/tests/reorder_code/expected/reorder_class_docstring_misplaced.gd
+++ b/tests/reorder_code/expected/reorder_class_docstring_misplaced.gd
@@ -2,11 +2,11 @@ class_name TestClass
 extends Node
 
 
-## This is the class docstring
-## It has multiple lines.
-func a():
+func b():
 	pass
 
 
-func b():
+## This is the class docstring
+## It has multiple lines.
+func a():
 	pass

--- a/tests/reorder_code/expected/reorder_complete.gd
+++ b/tests/reorder_code/expected/reorder_complete.gd
@@ -56,25 +56,25 @@ func _exit_tree():
 	pass
 
 
-func get_public_property() -> float:
-	return regular_variable
-
-
 @rpc("authority", "call_remote", "reliable")
 func public_method() -> int:
 	return TEST_CONSTANT
+
+
+func get_public_property() -> float:
+	return regular_variable
 
 
 func set_public_property(value: float):
 	regular_variable = value
 
 
-func _get_private_property() -> bool:
-	return _private_regular
-
-
 func _private_method() -> String:
 	return _PRIVATE_CONSTANT
+
+
+func _get_private_property() -> bool:
+	return _private_regular
 
 
 func _set_private_property(value: bool):

--- a/tests/reorder_code/expected/reorder_regions.gd
+++ b/tests/reorder_code/expected/reorder_regions.gd
@@ -2,7 +2,7 @@ class_name Test
 extends Node
 
 
-func a():
+func c():
 	pass
 
 
@@ -12,7 +12,7 @@ func bar():
 #endregion
 
 
-func c():
+func a():
 	pass
 
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #131 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
This removes reordering elements alphabetically.

**Other information**
I'd be open to re-adding this under an `--alphabetize` option (or similar) if there's interest for it.

I personally just wanted this behaviour before the upcoming Godot Wild Jam.