### PR TITLE
Fix comment indentation test case

### DIFF
--- a/tests/expected/comments_basic.gd
+++ b/tests/expected/comments_basic.gd
@@ -30,5 +30,5 @@ func do_another_thing() -> void:
 
 func test_function():
 	var a = "test"
-# This comment should stay inside of the function body
+	# This comment should stay inside of the function body
 	print(a)


### PR DESCRIPTION
The test case added for #120 and #124 has its expected state incorrectly formatted, causing the test to fail. The actual code works just fine and does resolve those issues.

I have updated the expected case with the correct formatting and the test now passes as expected!