### PR TITLE
Safe mode: fix panic when annotation doesn't have a name

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -53,7 +53,6 @@ impl Formatter {
             .unwrap();
         let tree = parser.parse(&content, None).unwrap();
         let mut input_tree = GdTree::from_ts_tree(&tree, content.as_bytes());
-        input_tree.postprocess();
 
         Self {
             content,
@@ -145,6 +144,7 @@ impl Formatter {
     #[inline(always)]
     fn finish(mut self) -> Result<String, Box<dyn std::error::Error>> {
         if self.config.safe {
+            self.input_tree.postprocess();
             self.tree = self.parser.parse(&self.content, None).unwrap();
 
             let output_tree = GdTree::from_ts_tree(&self.tree, self.content.as_bytes());
@@ -587,8 +587,9 @@ impl GdTree {
                             if child.grammar_name != "annotation" {
                                 return None;
                             }
-                            let annotation_name =
-                                self.nodes[child.children[0]].text.as_deref().unwrap();
+                            let Some(annotation_name) = &self.nodes[child.children[0]].text else {
+                                return None;
+                            };
                             if annotation_name != "onready" && annotation_name != "export" {
                                 return None;
                             }


### PR DESCRIPTION
Fixes panic mentioned in https://github.com/GDQuest/GDScript-formatter/issues/145. Annotation may not have an identifier as the first child due to parsing error, for example.

I also moved input tree's `postprocess()` to `Formatter::finish()`, to avoid doing unnecessary work when safe mode is disabled.