### PR TITLE
chore: remove export-ignore from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,1 @@
 * text=auto eol=lf
-
-# Only include the addons folder when downloading from the Godot Asset Library
-/**        export-ignore
-/addons    !export-ignore
-/addons/** !export-ignore


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

This MR fix an issue on the nix packaging

**Does this PR introduce a breaking change?**

No breaking changes

## Change ##


**What is the current behavior?** 

Actually, when we run the formatter with nix, we have the following error.
```sh
$ nix run 'github:GDQuest/GDScript-formatter'
error: path '«github:GDQuest/GDScript-formatter/48a2b518515aea63d8f98ee40f9557aaca065b9e»/flake.nix' does not exist
```
Indicates that the `flake.nix` file does not exists.

It seems that this is due to the `.gitattributes` file, which ignores everything except the addons folder.

**What is the new behavior?**

If I remove the "export-ignore" clauses, nix can find all the files, build the project, and run the formatter normally.

```sh
$ nix run github:florianvazelle/GDScript-formatter?ref=2c317c8622e9887af65d826fc24634aab08c2190
A GDScript formatter following the official style guide

Usage: gdscript-formatter [OPTIONS] [FILES]... [COMMAND]

Commands:
  lint  Lint GDScript files for style and convention issues
  help  Print this message or the help of the given subcommand(s)

Arguments:
  [FILES]...  The GDScript file(s) to format. If no file paths are provided, the program reads from standard input and
              outputs to standard output

Options:
      --stdout             Output formatted code to stdout without changing FILES
  -c, --check              Check if FILES are formatted, making no changes
      --use-spaces         Use spaces for indentation instead of tabs
      --indent-size <NUM>  Set how many spaces to use for indentation [default: 4]
      --reorder-code       Reorder code to follow the official GDScript style guide
  -s, --safe               Enable safe mode
  -h, --help               Print help (see more with '--help')
  -V, --version            Print version
```

**Other information**

This may be used by your CI to export only the addons ? I am open to suggestions :slightly_smiling_face: 