### PR TITLE
feat: Add functionality to manually install formatter plugins via zip…

### DIFF
--- a/addons/GDQuest_GDScript_formatter/menu.gd
+++ b/addons/GDQuest_GDScript_formatter/menu.gd
@@ -11,6 +11,7 @@ const MENU_ITEMS = {
 	"lint_script": "Lint Current Script",
 	"reorder_code": "Reorder Code",
 	"install_update": "Install or Update Formatter",
+	"manual_install": "Install Formatter Manually",
 	"uninstall": "Uninstall Formatter",
 	"report_issue": "Report Issue",
 	"help": "Help",
@@ -117,6 +118,11 @@ func _populate_menu(show_uninstall: bool = true) -> void:
 	popup_menu.add_item(MENU_ITEMS["install_update"], current_item_index)
 	popup_menu.set_item_metadata(current_item_index, "install_update")
 	popup_menu.set_item_tooltip(current_item_index, "Download the latest version of the GDScript Formatter")
+	current_item_index += 1
+
+	popup_menu.add_item(MENU_ITEMS["manual_install"], current_item_index)
+	popup_menu.set_item_metadata(current_item_index, "manual_install")
+	popup_menu.set_item_tooltip(current_item_index, "Manually install GDScript Formatter")
 	current_item_index += 1
 
 	if show_uninstall:

--- a/addons/GDQuest_GDScript_formatter/plugin.gd
+++ b/addons/GDQuest_GDScript_formatter/plugin.gd
@@ -50,6 +50,7 @@ var connection_list: Array[Resource] = []
 var installer: FormatterInstaller = null
 var formatter_cache_dir: String
 var menu: FormatterMenu = null
+var file_select_dialog: EditorFileDialog = null
 
 
 func _init() -> void:
@@ -102,6 +103,22 @@ func _enter_tree() -> void:
 	menu.menu_item_selected.connect(_on_menu_item_selected)
 	menu.update_menu(is_formatter_installed_locally())
 
+	file_select_dialog = EditorFileDialog.new()
+	file_select_dialog.access = EditorFileDialog.ACCESS_FILESYSTEM
+	file_select_dialog.file_mode = EditorFileDialog.FILE_MODE_OPEN_FILE
+	file_select_dialog.filters = ["*.zip ; ZIP Archives"]
+	file_select_dialog.title = "Select Formatter zip file"
+	get_editor_interface().get_base_control().add_child(file_select_dialog)
+	installer.show_file_select_dialog.connect(
+		func _on_show_file_select_dialog():
+			if is_instance_valid(file_select_dialog):
+				file_select_dialog.popup_centered()
+	)
+	file_select_dialog.file_selected.connect(
+		func _on_file_selected(path: String):
+			installer.zip_file_selected.emit(path)
+	)
+
 	update_shortcut()
 	resource_saved.connect(_on_resource_saved)
 
@@ -123,6 +140,10 @@ func _exit_tree() -> void:
 		menu.remove_formatter_menu()
 		menu.queue_free()
 		menu = null
+
+	if is_instance_valid(file_select_dialog):
+		file_select_dialog.queue_free()
+		file_select_dialog = null
 
 
 func _shortcut_input(event: InputEvent) -> void:
@@ -380,6 +401,8 @@ func _on_menu_item_selected(command: String) -> void:
 			reorder_code()
 		"install_update":
 			installer.install_or_update_formatter()
+		"manual_install":
+			installer.manual_install_formatter()
 		"uninstall":
 			uninstall_formatter()
 		"report_issue":


### PR DESCRIPTION
feat: Add functionality to manually install formatter plugins via zip files in the menu

**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- [x] You tested the changes.

Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
This PR introduces a new feature that allows users to manually install formatter plugins from local zip files, providing an alternative installation method when GitHub access is unreliable.

**Does this PR introduce a breaking change?**
No, this change is fully backward compatible. The existing GitHub download functionality remains unchanged, and the local zip installation is added as an additional option.

## New feature or change ##
Added a new menu option to install formatter from local zip file, which is especially useful in network environments with limited access to GitHub.

**What is the current behavior?** 
Currently, the plugin only supports downloading formatter binaries directly from GitHub releases. Users in regions with poor GitHub connectivity may experience frequent download failures.

**What is the new behavior?**
Users now have two installation options:
1. The original GitHub download functionality (unchanged)
2. A new manual installation option that allows selecting a pre-downloaded zip file from the local file system

The new functionality extracts and installs the formatter binary from the local zip file, providing a reliable fallback when GitHub access is problematic.

**Other information**
This change enhances the plugin's usability in various network environments while maintaining full compatibility with existing workflows. The implementation includes proper error handling for zip file operations and maintains the same installation directory structure as the GitHub download method.