### PR TITLE
Added ignored directories for on-save functionality

### DIFF
--- a/addons/GDQuest_GDScript_formatter/plugin.gd
+++ b/addons/GDQuest_GDScript_formatter/plugin.gd
@@ -22,7 +22,8 @@ const SETTING_FORMATTER_PATH = "formatter_path"
 const SETTING_LINT_ON_SAVE = "lint_on_save"
 const SETTING_LINT_LINE_LENGTH = "lint_line_length"
 const SETTING_LINT_IGNORED_RULES = "lint_ignored_rules"
-const SETTING_IGNORED_DIRECTORIES = "on_save_ignored_directories"
+# Directories to ignore when Format on Save is enabled
+const SETTING_IGNORED_DIRECTORIES = "format_on_save_ignored_directories"
 
 const COMMAND_PALETTE_CATEGORY = "gdquest gdscript formatter/"
 const COMMAND_PALETTE_FORMAT_SCRIPT = "Format GDScript"
@@ -204,12 +205,23 @@ func _on_resource_saved(saved_resource: Resource) -> void:
 		return
 
 	var script := saved_resource as GDScript
-	
+
 	var ignored_directories := get_editor_setting(SETTING_IGNORED_DIRECTORIES)
 	var path = script.resource_path.trim_prefix("res://")
 
-	for dir: String in ignored_directories:
-		if path.begins_with(dir):
+	var script_path_parts := path.split("/")
+
+	for directory: String in ignored_directories:
+		var normalized_dir := directory.trim_prefix("res://")
+		var directory_parts := normalized_dir.split("/")
+
+		var matches := true
+		for i in range(directory_parts.size()):
+			if directory_parts[i] != script_path_parts[i]:
+				matches = false
+				break
+
+		if matches:
 			return
 
 	if not has_command(get_editor_setting(SETTING_FORMATTER_PATH)) or not is_instance_valid(script):


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Adds a setting to exclude certain paths for on-save formatting/linting.


**Does this PR introduce a breaking change?**
It will by default cause files in the addon-folder to be excluded from on-save formatting/linting, which might confuse people who expected that to work.


## New feature or change ##


**What is the current behavior?** 
If "format on save" is enabled, all files are formatted and/or linted on save.


**What is the new behavior?**
Files that are in excluded paths are no longer formatted and/or linted on save.


**Other information**
I was just kinda annoyed of big reformats when tweaking other people's addons (this one included). Hoping this simple feature is helpful for someone!