### PR TITLE
Allow bitwise binary operators to be line wrapped

### DIFF
--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -112,7 +112,8 @@
   [
     "+" "-" "*" "/" "%" "**"
     "==" "!=" "<" ">" "<=" ">=" "and"
-    "or" "in" "is" "&&" "||" "not"]
+    "or" "in" "is" "&&" "||" "not"
+    "&" "|" "^" "<<" ">>"]
   @prepend_input_softline @append_input_softline)
 ; Comparison operators (+ "as" keyword which needs the same spacing)
 [
@@ -121,10 +122,6 @@
 @prepend_space @append_space
 ; not can be at the start of an expression, so we handle it separately - needs another query for the case "is not"
 "not" @append_space
-; Bitwise operators
-[
-  "&" "|" "^" "<<" ">>"]
-@prepend_space @append_space
 ; ~ is generally right next to the variable it operates on, so we don't add a space after it
 [
     "=" ":=" "+=" "-=" "*=" "/=" "%=" "**=" "&=" "|=" "^=" "<<=" ">>="]

--- a/tests/expected/multiline.gd
+++ b/tests/expected/multiline.gd
@@ -36,3 +36,12 @@ func foo():
 		],
 		2,
 	]
+
+	var sum = (1 +
+		2
+	)
+
+	var bitflags = (
+		0x0b
+		| 0xa0
+	)

--- a/tests/input/multiline.gd
+++ b/tests/input/multiline.gd
@@ -41,3 +41,12 @@ func foo():
 			],
 		2
 		]
+
+	var sum =    (1 + 
+2
+)
+
+	var bitflags = (
+				0x0b
+			| 0xa0
+		)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [X] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes.


Related issue (if applicable): #212 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Allows bitwise binary operators to be line wrapped the same way other binary operators are.


**Does this PR introduce a breaking change?**
No. It will preserve formatting that wouldn't have been preserved before, but it shouldn't reformat anything that was formatted with previous versions.


**Other information**
I have no experience with Topiary and Tree-sitter, so take this PR with grain of salt -- but the fix seemed simple enough :)

It wasn't obvious to me if the previous bitwise rules with `@prepend_space @append_space` should be kept. Based on the test suite results when removing them, and my reading of the Topiary docs, they should no longer serve any purpose. But the comparison operators _do_ have both rules, even if in the tests that only affects the `in` operator (specifically with `for...in`).
