### PR TITLE
feat: Indent backslash continuation lines according to style guide

### DIFF
--- a/queries/gdscript.scm
+++ b/queries/gdscript.scm
@@ -246,3 +246,10 @@
 (get_node) @leaf
 
 (line_continuation) @prepend_space @append_antispace @append_hardline
+; Indent nodes that immediately follows a line continuation ("\") by two levels,
+; following the GDScript style guide. The line_continuation token only appears
+; as a direct child of these three node types. We're leaving arrays, dicts, and
+; enums out because they should have a single indent level inside their bodies
+(attribute (line_continuation) @append_indent_start @append_indent_start . (_) @append_indent_end @append_indent_end)
+(binary_operator (line_continuation) @append_indent_start @append_indent_start . (_) @append_indent_end @append_indent_end)
+(variable_statement (line_continuation) @append_indent_start @append_indent_start . (_) @append_indent_end @append_indent_end)

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -53,6 +53,7 @@ struct Formatter {
     input_tree: GdTree,
     tree: Tree,
     original_source: Option<String>,
+    indent_string: String,
 }
 
 impl Formatter {
@@ -72,6 +73,11 @@ impl Formatter {
         } else {
             None
         };
+        let indent_string = if config.use_spaces {
+            " ".repeat(config.indent_size)
+        } else {
+            "\t".to_string()
+        };
 
         Self {
             original_source,
@@ -80,22 +86,17 @@ impl Formatter {
             tree,
             input_tree,
             parser,
+            indent_string,
         }
     }
 
     #[inline(always)]
     fn format(&mut self) -> Result<&mut Self, Box<dyn std::error::Error>> {
-        let indent_string = if self.config.use_spaces {
-            " ".repeat(self.config.indent_size)
-        } else {
-            "\t".to_string()
-        };
-
         let language = Language {
             name: "gdscript".to_owned(),
             query: TopiaryQuery::new(&tree_sitter_gdscript::LANGUAGE.into(), QUERY).unwrap(),
             grammar: tree_sitter_gdscript::LANGUAGE.into(),
-            indent: Some(indent_string),
+            indent: Some(self.indent_string.clone()),
         };
 
         let mut output = Vec::new();
@@ -475,12 +476,31 @@ impl Formatter {
         self
     }
 
+    /// This function indents lines following a line continuation by two
+    /// levels to match style guide.  Note that this function will only work
+    /// with an up-to-date tree-sitter tree.
+    #[inline(always)]
+    fn fix_line_continuation_indentation(&mut self) -> &mut Self {
+        let re = RegexBuilder::new(r"\\\r?\n")
+            .build()
+            .expect("line continuation regex should compile");
+
+        self.regex_replace_all_outside_strings(
+            re,
+            format!("$0{}{}", self.indent_string, self.indent_string),
+        );
+
+        self
+    }
+
     /// This function runs postprocess passes that uses tree-sitter.
     #[inline(always)]
     fn postprocess_tree_sitter(&mut self) -> &mut Self {
         self.tree = self.parser.parse(&self.content, None).unwrap();
 
-        self.handle_two_blank_line()
+        self.fix_line_continuation_indentation()
+            .handle_two_blank_line()
+
     }
 
     /// Replaces every match of regex `re` with `rep`, but only if the match is
@@ -509,7 +529,9 @@ impl Formatter {
                 .root_node()
                 .descendant_for_byte_range(start_byte, start_byte)
                 .unwrap();
-            if node.kind() == "string" {
+            // String nodes may also contain escape_sequence nodes.  These are
+            // found when a backslash is present within a string.
+            if node.kind() == "string" || node.kind() == "escape_sequence" {
                 continue;
             }
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -476,31 +476,12 @@ impl Formatter {
         self
     }
 
-    /// This function indents lines following a line continuation by two
-    /// levels to match style guide.  Note that this function will only work
-    /// with an up-to-date tree-sitter tree.
-    #[inline(always)]
-    fn fix_line_continuation_indentation(&mut self) -> &mut Self {
-        let re = RegexBuilder::new(r"\\\r?\n")
-            .build()
-            .expect("line continuation regex should compile");
-
-        self.regex_replace_all_outside_strings(
-            re,
-            format!("$0{}{}", self.indent_string, self.indent_string),
-        );
-
-        self
-    }
-
     /// This function runs postprocess passes that uses tree-sitter.
     #[inline(always)]
     fn postprocess_tree_sitter(&mut self) -> &mut Self {
         self.tree = self.parser.parse(&self.content, None).unwrap();
 
-        self.fix_line_continuation_indentation()
-            .handle_two_blank_line()
-
+        self.handle_two_blank_line()
     }
 
     /// Replaces every match of regex `re` with `rep`, but only if the match is

--- a/tests/expected/line_continuation.gd
+++ b/tests/expected/line_continuation.gd
@@ -1,4 +1,4 @@
 func _handles(resource: Resource) -> bool:
 	return resource is NoiseTexture2D \
-	or resource is GradientTexture1D \
-	or resource is GradientTexture2D
+			or resource is GradientTexture1D \
+			or resource is GradientTexture2D

--- a/tests/expected/line_continuation_indent.gd
+++ b/tests/expected/line_continuation_indent.gd
@@ -1,0 +1,15 @@
+var thing = \
+		my_long_function()
+
+thing \
+		.calling(1) \
+		.a(12314) \
+		.long() \
+		.chain("a string breaks things") \
+		.of() \
+		.functions()
+
+var string = "\
+	this is a really long \
+	string, but we don't want \
+	to change the indentation."

--- a/tests/expected/line_continuation_indent.gd
+++ b/tests/expected/line_continuation_indent.gd
@@ -1,15 +1,31 @@
-var thing = \
-		my_long_function()
+var is_valid: bool = some_condition \
+		and another_condition
 
-thing \
-		.calling(1) \
-		.a(12314) \
-		.long() \
-		.chain("a string breaks things") \
-		.of() \
-		.functions()
 
-var string = "\
-	this is a really long \
-	string, but we don't want \
-	to change the indentation."
+func _handles(resource: Resource) -> bool:
+	return resource is NoiseTexture2D \
+			or resource is GradientTexture1D
+
+
+func _process(delta: float) -> void:
+	if is_on_floor() \
+			and not is_jumping:
+		apply_gravity(delta)
+
+
+func _calculate() -> float:
+	var x: float = some_long_value \
+			+ another_value
+	return x
+
+
+func _ready() -> void:
+	node.set_position(Vector2.ZERO) \
+			.rotated(PI)
+
+
+# string with \ must not change indentation
+func _get_message() -> String:
+	var greeting: String = "\
+	Hello world"
+	return greeting

--- a/tests/input/line_continuation_indent.gd
+++ b/tests/input/line_continuation_indent.gd
@@ -1,15 +1,31 @@
-var thing = \
-my_long_function()
+var is_valid: bool = some_condition \
+and another_condition
 
-thing \
-.calling(1) \
-.a(12314) \
-.long() \
-.chain("a string breaks things") \
-.of() \
-.functions()
 
-var string = "\
-	this is a really long \
-	string, but we don't want \
-	to change the indentation."
+func _handles(resource: Resource) -> bool:
+	return resource is NoiseTexture2D \
+	or resource is GradientTexture1D
+
+
+func _process(delta: float) -> void:
+	if is_on_floor() \
+	and not is_jumping:
+		apply_gravity(delta)
+
+
+func _calculate() -> float:
+	var x: float = some_long_value \
+	+ another_value
+	return x
+
+
+func _ready() -> void:
+	node.set_position(Vector2.ZERO) \
+	.rotated(PI)
+
+
+# string with \ must not change indentation
+func _get_message() -> String:
+	var greeting: String = "\
+	Hello world"
+	return greeting

--- a/tests/input/line_continuation_indent.gd
+++ b/tests/input/line_continuation_indent.gd
@@ -1,0 +1,15 @@
+var thing = \
+my_long_function()
+
+thing \
+.calling(1) \
+.a(12314) \
+.long() \
+.chain("a string breaks things") \
+.of() \
+.functions()
+
+var string = "\
+	this is a really long \
+	string, but we don't want \
+	to change the indentation."


### PR DESCRIPTION


**Please check if the PR fulfills these requirements:**

- [ ] The commit message follows our guidelines.
     - Where are these guidelines?  They're not in the README.md, there's no CONTRIBUTORS.md
- For bug fixes and features:
    - [X] You tested the changes.


Related issue (if applicable): #180

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

Feature, implement proper line continuation indention.
From gdscript style guide[^1]:
> Use 2 indent levels to distinguish continuation lines from regular code blocks.

[^1]: https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html#indentation

**Does this PR introduce a breaking change?**

It does change the indentation of one existing test.  I don't consider that breaking, but it's unclear.

## New feature or change ##

**What is the current behavior?** 
Currently the formatter indents continuation lines to the same level as the first line:

```gdscript
func test(thing):
    thing.calling(1) \
    .a(12314) \
    .long() \
    .chain("a string breaks things") \
    .of() \
    .functions()
```


**What is the new behavior?**

With this change, continuation lines (joined with a backslash) are formatted with double indention:

```gdscript
func test(thing):
    thing.calling(1) \
            .a(12314) \
            .long() \
            .chain("a string breaks things") \
            .of() \
            .functions()
```


**Other information**
