### PR TITLE
:sparkles: Add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: gdscript-formatter
+  name: GDScript Formatter
+  description: Format GDScript files using gdscript-formatter
+  entry: gdscript-formatter
+  language: system
+  files: \.gd$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,0 @@
-- id: gdscript-formatter
-  name: GDScript Formatter
-  description: Format GDScript files using gdscript-formatter
-  entry: gdscript-formatter
-  language: system
-  files: \.gd$

--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ gdscript-formatter --check path/to/file.gd
 
 To see other possible options, run `gdscript-formatter` without any arguments.
 
+## Git pre-commit hook
+
+You can run the `gdscript-formatter` automatically on staged `.gd` prior to each commit. This repository includes a pre-commit hook you can copy into your project.
+
+From the root of your project, run:
+
+```sh
+cp path/to/GDScript-formatter/hooks/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+This copies the hook into `.git/hooks/`, where Git looks for hooks to run automatically. Git will now run the formatter on your staged `.gd` files before every commit.
+
 ## Linting GDScript files
 
 The formatter also includes a linter that checks for style and convention issues according to the official GDScript style guide.

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+staged=$(git diff --cached --name-only --diff-filter=ACM | grep '\.gd$')
+[ -z "$staged" ] && exit 0
+echo "$staged" | xargs gdscript-formatter
+git add $staged


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #141 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

- New feature
 
**Does this PR introduce a breaking change?**

- No

## New feature or change ##

**What is the current behavior?** 

There is no standard Git pre-commit hook, so users who want to use gdscript-formatter as a pre-commit hook have to configure it manually.

**What is the new behavior?**

Users can copy this pre-commit hook into their `.git/hooks/pre-commit` directory to automatically format `.gd` files prior to each Git commit. 
                                                                                             
**Other information**

Fixes #141
