### PR TITLE
fix: skip reorder when file has parse errors to prevent data loss

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -129,6 +129,16 @@ impl Formatter {
         }
 
         self.tree = self.parser.parse(&self.content, Some(&self.tree)).unwrap();
+
+        // The reorder query uses (_) which silently skips ERROR nodes, so any
+        // top-level declaration wrapped in an ERROR node will be lost from the
+        // output. Bail out instead of producing a file with missing functions.
+        if self.tree.root_node().has_error() {
+            eprintln!(
+                "Warning: Parse errors detected, skipping code reordering to avoid data loss."
+            );
+            return Ok(self);
+        }
         match crate::reorder::reorder_gdscript_elements(&self.tree, &self.content) {
             Ok(reordered) => {
                 self.content = reordered;

--- a/tests/reorder_code/expected/issue_233.gd
+++ b/tests/reorder_code/expected/issue_233.gd
@@ -1,0 +1,16 @@
+func jump(force: float) -> void:
+	self.velocity.y = force
+	is_shooting = false
+func shoot() -> void:
+	var pos: Vector2 = muzzle_right.global_position
+	var direction: Vector2 = Vector2.RIGHT
+	if is_facing_left:
+		pos = muzzle_left.global_position
+		direction = Vector2.LEFT
+
+	var lazer: Projectile = Instancer.instance_scene_to_level(Instancer.laster_scene, pos) as Projectile
+	if lazer != null:
+		lazer.launch(direction, lazer_speed)
+
+	is_shooting = false
+	var yozora: bool.

--- a/tests/reorder_code/input/issue_233.gd
+++ b/tests/reorder_code/input/issue_233.gd
@@ -1,0 +1,18 @@
+func jump(force: float) -> void:
+	self.velocity.y = force
+	is_shooting = false
+
+
+func shoot() -> void:
+	var pos: Vector2 = muzzle_right.global_position
+	var direction: Vector2 = Vector2.RIGHT
+	if is_facing_left:
+		pos = muzzle_left.global_position
+		direction = Vector2.LEFT
+
+	var lazer: Projectile = Instancer.instance_scene_to_level(Instancer.laster_scene, pos) as Projectile
+	if lazer != null:
+		lazer.launch(direction, lazer_speed)
+
+	is_shooting = false
+	var yozora: bool.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #233

**What kind of change does this PR introduce?**

Bug fix.

**Does this PR introduce a breaking change?**

No.

## New feature or change ##


**What is the current behavior?**

When running with `--reorder-code` on a file that contains invalid GDScript syntax, the formatter silently deletes entire function definitions. For example, a trailing `.` after a type annotation (`var yozora: bool.`) causes tree-sitter's error recovery to wrap the surrounding function in an `ERROR` node. The reorder query uses `(_)` as a wildcard, which excludes `ERROR` nodes, so the affected function is never collected and simply disappears from the output.

**What is the new behavior?**

Before running the reorder step, the formatter checks `tree.root_node().has_error()`. If parse errors are present, reordering is skipped and the already-formatted code is returned as-is, with a warning printed to stderr. All functions are preserved.

**Other information**

A regression test has been added in `tests/reorder_code/` covering the exact scenario from the issue.
Claude Code was used to create this PR but I did human verify the changes.