### PR TITLE
Generate release notes from changelog

### DIFF
--- a/.github/generate_release_notes.py
+++ b/.github/generate_release_notes.py
@@ -1,0 +1,32 @@
+import re
+
+def main() -> None:
+    """Generate release notes for the latest GitHub release."""
+
+    with open("CHANGELOG.md", encoding="utf-8") as file:
+        changelog = file.read()
+
+    first_section = re.search(r"^### ", changelog, re.MULTILINE)
+    if first_section is None:
+        raise RuntimeError("Could not find the first changelog section.")
+
+    next_release = re.search(r"^## ", changelog[first_section.start():], re.MULTILINE)
+
+    if next_release is None:
+        raise RuntimeError("Could not find the next release heading.")
+
+    latest_changes = changelog[first_section.start() : first_section.start() + next_release.start()].strip()
+
+    release_notes = f"""A fast code formatter for GDScript in Godot 4.
+
+## Changelog
+
+{latest_changes}
+
+Learn more about the formatter in the [GDScript Formatter documentation](https://www.gdquest.com/library/gdscript_formatter/)
+"""
+
+    print(release_notes)
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,17 +122,12 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Generate release notes
+        run: python .github/generate_release_notes.py > release-notes.md
+
       - name: Create Release
         run: |
-          gh release create "${{ github.ref_name }}" \
-            --verify-tag \
-            --draft \
-            --title "GDScript formatter ${{ github.ref_name }}" \
-            --notes "A fast code formatter for GDScript in Godot 4.
-
-            You can learn how to install, use, configure, and integrate the formatter into your workflow on this page:
-
-            https://www.gdquest.com/library/gdscript_formatter/"
+          gh release create "${{ github.ref_name }}" --verify-tag --draft --title "GDScript formatter ${{ github.ref_name }}" --notes-file release-notes.md
 
           gh release upload "${{ github.ref_name }}" artifacts/*.zip
           gh release edit "${{ github.ref_name }}" --draft=false


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] The changes were tested.

Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

This PR updates the release workflow to generate GitHub release notes from the latest entry in `CHANGELOG.md`.

**Does this PR introduce a breaking change?**

No.

## New feature or change ##

- Added `.github/generate_release_notes.py` to extract the latest changelog entry.
- Updated the release workflow to generate `release-notes.md` before creating a release.
- Changed the release creation step to use `--notes-file` instead of hardcoded release notes.

**What is the current behavior?**

The release workflow uses manually written release notes embedded directly in the GitHub Actions workflow. Changes documented in `CHANGELOG.md` are not automatically included in GitHub releases.

**What is the new behavior?**

The release workflow generates release notes from the latest `CHANGELOG.md` entry and uses them when creating the GitHub release.

This assumes `CHANGELOG.md` has been updated with the release notes before the release workflow is triggered.

**Other information**

This keeps GitHub releases synchronized with the changelog and removes the need to manually update release notes in the workflow.