### PR TITLE
docs: add setup-gdscript-formatter GitHub Action to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can find binaries for Windows, macOS, and Linux in the [releases tab](https:
 
 - **Arch Linux:** Community maintained AUR Package [gdscript-formatter-bin](https://aur.archlinux.org/packages/gdscript-formatter-bin).
 - **Windows:** Community maintained Scoop package (`scoop install` [`extras/gdscript-formatter`](https://github.com/ScoopInstaller/Extras/blob/master/bucket/gdscript-formatter.json))
+- **GitHub Actions:** Community maintained [setup-gdscript-formatter](https://github.com/Modern-Arts-Research-Stories-Next/setup-gdscript-formatter) action for installing the formatter in GitHub Actions workflows.
 
 To recursively format all GDScript files in the current folder, run:
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [ ] You tested the changes.

Related issue (if applicable): #288

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

Documentation update to add the community-maintained `setup-gdscript-formatter` GitHub Action to the README.

**Does this PR introduce a breaking change?**

No.

## New feature or change ##

Added `setup-gdscript-formatter` to the "Alternative sources" section in the installation instructions.

This makes users aware of a GitHub Action that simplifies installing GDScript Formatter in GitHub Actions workflows.

**What is the current behavior?**

The README documents several alternative installation methods, such as AUR and Scoop packages, but does not mention the GitHub Action for CI workflows.

**What is the new behavior?**

The README now includes `setup-gdscript-formatter` as a community-maintained GitHub Action for installing the formatter in GitHub Actions workflows.

**Other information**

No code changes are introduced; this PR only updates documentation.