### PR TITLE
pre-commit config update

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: gdscript-formatter
   name: GDScript Formatter
   description: Format GDScript files with gdscript-formatter
-  entry: gdscript-formatter --safe
+  entry: gdscript-formatter
   language: unsupported
   files: \.gd$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,9 @@
   entry: gdscript-formatter
   language: unsupported
   files: \.gd$
+- id: gdscript-linter
+  name: GDScript Linter
+  description: Lint GDScript files with gdscript-formatter
+  entry: gdscript-formatter lint
+  language: unsupported
+  files: \.gd$


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines. _NOTE: I could not find any commit message guidelines in the docs and based on other commits I think my messages are fine._
- For bug fixes and features:
    - [x] You tested the changes. _NOTE: No testing needed_




Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
- remove deprecated `--safe` flag from formatter call in pre-commit-config
It is not replaced with `--verify-structure` to give the user freedom and control.
- added lint command to pre-commit-config


**Does this PR introduce a breaking change?**
No


## New feature or change ##


**What is the current behavior?** 
- pre-commit hook always uses `--safe` flag, even if the user does not want it


**What is the new behavior?**
- the user decides which flags the formatter is run with when called via pre-commit
- the linter is available as its own hook


**Other information**
