### PR TITLE
ci: add WinGet publishing for releases 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
           retention-days: 10
 
   publish-release:
-    name: Publish release
+    name: Publish GitHub release
     needs:
       - build-binaries
       - package-godot-addon
@@ -134,3 +134,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
+
+  winget:
+    name: Publish to WinGet
+    runs-on: windows-latest
+    needs: publish-release
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Setup WingetCreate
+        run: curl.exe -L https://aka.ms/wingetcreate/latest -o wingetcreate.exe
+        shell: pwsh
+        
+      - name: Publish to WinGet
+        run: |
+          $version = "${{ github.ref_name }}"
+
+          $urls = @(
+          "https://github.com/GDQuest/GDScript-formatter/releases/download/$version/gdscript-formatter-$version-windows-x86_64.exe.zip|x64",
+          "https://github.com/GDQuest/GDScript-formatter/releases/download/$version/gdscript-formatter-$version-windows-aarch64.exe.zip|arm64"
+          )
+
+          .\wingetcreate.exe update GDQuest.GDScript.Formatter --version $version --urls $urls --submit
+        env:
+          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+        shell: pwsh


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- [ ] You tested the changes.

Related issue (if applicable): #239

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

This PR adds automatic WinGet publishing support to the release workflow.

**Does this PR introduce a breaking change?**

No.

## New feature or change ##

- Added a WinGet publishing job to the release workflow.
- Automated WinGet package updates after releases.

**What is the current behavior?**

Releases are published to GitHub Releases, but WinGet package updates are handled manually.

**What is the new behavior?**

WinGet package updates are automatically submitted after a successful GitHub release.

**Other information**

The WinGet publishing job runs after the GitHub release job completes successfully.