### PR TITLE
docs: add WinGet package to README as alternative source

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ You can find binaries for Windows, macOS, and Linux in the [releases tab](https:
 
 **Alternative sources:**
 
-- **Arch Linux:** Community maintained AUR Package [gdscript-formatter-bin](https://aur.archlinux.org/packages/gdscript-formatter-bin).
-- **Windows:** Community maintained Scoop package (`scoop install` [`extras/gdscript-formatter`](https://github.com/ScoopInstaller/Extras/blob/master/bucket/gdscript-formatter.json))
+- **Arch Linux:** Community maintained AUR package [gdscript-formatter-bin](https://aur.archlinux.org/packages/gdscript-formatter-bin).
+- **Windows:** Community maintained Scoop package (`scoop install` [`extras/gdscript-formatter`](https://github.com/ScoopInstaller/Extras/blob/master/bucket/gdscript-formatter.json)).
+- **Windows:** WinGet package (`winget install` `GDQuest.GDScript.Formatter`).
 - **GitHub Actions:** Community maintained [setup-gdscript-formatter](https://github.com/Modern-Arts-Research-Stories-Next/setup-gdscript-formatter) action for installing the formatter in GitHub Actions workflows.
 
 To recursively format all GDScript files in the current folder, run:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [ ] You tested the changes.

Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

Documentation update adding the WinGet package to the alternative sources list.

**Does this PR introduce a breaking change?**

No.

## New feature or change ##

Added the WinGet package entry for `GDQuest.GDScript.Formatter` in the README alternative sources section.

**What is the current behavior?**

The README lists Arch Linux, Scoop, and GitHub Actions as alternative sources.

**What is the new behavior?**

The README now includes WinGet as an alternative source.

**Other information**

N/A