### PR TITLE
Fix/351 asset store duplicate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
           retention-days: 10
 
   publish-release:
-    name: Publish release
+    name: Publish GitHub release
     needs:
       - build-binaries
       - package-godot-addon
@@ -134,3 +134,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
+
+  winget:
+    name: Publish to WinGet
+    runs-on: windows-latest
+    needs: publish-release
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Setup WingetCreate
+        run: curl.exe -L https://aka.ms/wingetcreate/latest -o wingetcreate.exe
+        shell: pwsh
+        
+      - name: Publish to WinGet
+        run: |
+          $version = "${{ github.ref_name }}"
+
+          $urls = @(
+          "https://github.com/GDQuest/GDScript-formatter/releases/download/$version/gdscript-formatter-$version-windows-x86_64.exe.zip|x64",
+          "https://github.com/GDQuest/GDScript-formatter/releases/download/$version/gdscript-formatter-$version-windows-aarch64.exe.zip|arm64"
+          )
+
+          .\wingetcreate.exe update GDQuest.GDScript.Formatter --version $version --urls $urls --submit
+        env:
+          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+        shell: pwsh


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [ ] You tested the changes.

Related issue (if applicable): #351

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

This PR fixes the release workflow so that the two Godot add-ons are packaged into separate ZIP archives instead of being bundled together.

**Does this PR introduce a breaking change?**

No.

## New feature or change ##

**What is the current behavior?**

The release workflow recursively packages the entire `addons/` directory into a single `godot-addon.zip` archive. This causes both `GDQuest_GDScript_formatter` and `GDQuest_GDScript_formatter_standalone` to be included in the same archive.

**What is the new behavior?**

The release workflow creates two separate archives:

- `godscript-formatter.zip` containing `GDQuest_GDScript_formatter`
- `godscript-formatter-standalone.zip` containing `GDQuest_GDScript_formatter_standalone`

Both archives are uploaded as release assets.

**Other information**

This addresses issue #351 by allowing each Godot add-on to be distributed independently without packaging both add-ons together.
